### PR TITLE
Added numSlides and current slide to screen

### DIFF
--- a/frontend/src/components/Town/interactables/PresentationAreaDocument.tsx
+++ b/frontend/src/components/Town/interactables/PresentationAreaDocument.tsx
@@ -81,11 +81,16 @@ export function PresentationAreaDocument({
     const slideListener = (newSlide: number) => {
       setCurrentSlide(newSlide);
     };
+    const numSlidesListener = (newNumSlides: number) => {
+      setNumSlides(newNumSlides);
+    };
     controller.addListener('documentChange', documentListener);
     controller.addListener('slideChange', slideListener);
+    controller.addListener('numSlidesChange', numSlidesListener);
     return () => {
       controller.removeListener('documentChange', documentListener);
       controller.removeListener('slideChange', slideListener);
+      controller.removeListener('numSlidesChange', numSlidesListener);
     };
   }, [controller]);
 


### PR DESCRIPTION
Added a basic component to keep track of the current slide for a given presentation as well as the total number of slides so both the presenter and viewer can get an idea of how far along the presentation is. To accomplish this, I added additional listeners for changes to numSlides and use that data as well as the existing current slide number to populate the new component. Below I added an image that shows this new component:

![presentation_slide_tracker](https://user-images.githubusercontent.com/17186604/204351147-e5e8154e-d63d-43e0-80c7-b3bd56223116.PNG)
